### PR TITLE
Add missing library for tcp_server.c

### DIFF
--- a/sts/tcp_server.c
+++ b/sts/tcp_server.c
@@ -5,6 +5,8 @@
 #include <netdb.h>
 #include <memory.h>
 #include <errno.h>
+#include <arpa/inet.h>
+#include <unistd.h>
 #include "common.h"
 
 /*Server process is running on this port no. Client has to send data to this port no*/


### PR DESCRIPTION
There are crash and warning errors happening when the library is missing.